### PR TITLE
Assign commits to the standard GitHub Actions bot

### DIFF
--- a/.github/workflows/render-docs.yml
+++ b/.github/workflows/render-docs.yml
@@ -107,6 +107,6 @@ jobs:
       uses: EndBug/add-and-commit@v9
       with:
         add: "${{ inputs.target-path }}"
-        author_name: "GitHub Action"
-        author_email: "action@github.com"
+        author_name: "github-actions[bot]"
+        author_email: "41898282+github-actions[bot]@users.noreply.github.com"
         message: "${{ inputs.commit-message }}"      

--- a/.github/workflows/render-docs.yml
+++ b/.github/workflows/render-docs.yml
@@ -38,6 +38,14 @@ on:
         description: 'Commit message'
         default: 'Update documentation'
         type: string
+      committer-name:
+        description: 'Username to use as author of the commit.'
+        default: 'github-actions[bot]'
+        type: string
+      committer-email:
+        description: 'Email address to use as author of the commit.'
+        default: '41898282+github-actions[bot]@users.noreply.github.com'
+        type: string
       debug:
         description: 'Enable debugging mode to provide additional output'
         default: false
@@ -107,6 +115,6 @@ jobs:
       uses: EndBug/add-and-commit@v9
       with:
         add: "${{ inputs.target-path }}"
-        author_name: "github-actions[bot]"
-        author_email: "41898282+github-actions[bot]@users.noreply.github.com"
+        author_name: "${{ inputs.committer-name }}"
+        author_email: "${{ inputs.committer-email }}"
         message: "${{ inputs.commit-message }}"      

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ The workflow has a couple of inputs that allows to configure the behaviour:
 - `fail-on-warnings` The command prints documentation issues such as missing documentation. This option makes the action fail when such issues are found. This allows to achieve 100% documentation coverage.
 - `commit` Defines whether the rendered markdown files should be committed to the repository automatically.
 - `commit-message` Defines the commit message to be used when `commit` is set to true.
+- `committer-name` Username to use as the author of the commit. Defaults to "github-actions[bot]".
+- `committer-email` Email address to use as the author of the commit. Defaults to the email for "github-actions[bot]".
 - `debug` Enable this option to get additional output from the tool. This allows to debug in case you get unexpected output from the command.
 
 ## 🐛 Reporting Issues

--- a/action.yml
+++ b/action.yml
@@ -85,6 +85,6 @@ runs:
     uses: EndBug/add-and-commit@v9
     with:
       add: "${{ inputs.target-path }}"
-      author_name: "GitHub Action"
-      author_email: "action@github.com"
+      author_name: "github-actions[bot]"
+      author_email: "41898282+github-actions[bot]@users.noreply.github.com"
       message: "${{ inputs.commit-message }}"      

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,12 @@ inputs:
   commit-message:
     description: 'Commit message'
     default: 'Update documentation'
+  committer-name:
+    description: 'Username to use as author of the commit.'
+    default: 'github-actions[bot]'
+  committer-email:
+    description: 'Email address to use as author of the commit.'
+    default: '41898282+github-actions[bot]@users.noreply.github.com'
   debug:
     description: 'Enable debugging mode to provide additional output'
     default: 'false'
@@ -85,6 +91,6 @@ runs:
     uses: EndBug/add-and-commit@v9
     with:
       add: "${{ inputs.target-path }}"
-      author_name: "github-actions[bot]"
-      author_email: "41898282+github-actions[bot]@users.noreply.github.com"
+      author_name: "${{ inputs.committer-name }}"
+      author_email: "${{ inputs.committer-email }}"
       message: "${{ inputs.commit-message }}"      


### PR DESCRIPTION
The action and reusable workflow commits the generated documentation to the repository. A username and email address must be configured for this commit.

## Change Default Commit Author

Previously, [an arbitrary GitHub account](https://github.com/actions-user) was used for this purpose. It is questionable whether it is appropriate to attribute commits to an arbitrary user who didn't make them and which was not explicitly provided for such a purpose. In addition, doing so is problematic because we require all contributors to sign a CLA, and so we would need to set up an exemption for this arbitrary user in order to allow the commits to pass the [CLA signing check](https://github.com/cla-assistant/cla-assistant).

So the better approach is to assign the commit to the standard GitHub Actions bot account. This account is already assigned machine generated commits by the infrastructure of several of Arduino's repositories and is already exempted from the CLA check:

- https://github.com/arduino/arduino-ide/blob/6d96e227eb9471ce923fcad4400c26c27cc32ed1/.github/workflows/i18n-weekly-pull.yml#L60
- https://github.com/arduino/arduino-ide/blob/6d96e227eb9471ce923fcad4400c26c27cc32ed1/.github/workflows/themes-weekly-pull.yml#L69
- https://github.com/arduino/arduino-cli/blob/b9edb782a265b99878b4bce489c1751c4dcbee61/.github/workflows/i18n-weekly-pull.yaml#L50
- https://github.com/arduino/arc/blob/549f3eed627d571fb4d5f11d83020db68f264f75/.github/workflows/figma-style-weekly-pull.yaml#L41

For example:

https://github.com/arduino/arduino-ide/pull/2597/commits

![image](https://github.com/user-attachments/assets/2f0a7f9a-2658-4421-b637-1ed498a77650)

There is some evidence that this usage of the bot is expected by GitHub:

https://github.com/actions/checkout/blob/main/README.md#push-a-commit-using-the-built-in-token

(there is some interesting related information in https://github.com/actions/checkout/pull/1707)

---

An alternative would have been to use Arduino's general purpose @ArduinoBot account. This account is assigned automated commits by some infrastructure used exclusively in Arduino's own projects. However, the "arduino/render-docs-github-action" action and reusable workflow may also be used in projects not owned by Arduino, and it probably isn't appropriate to assign commits to ArduinoBot in those repositories.

## Make Commit Author Configurable

The users of the action and reusable workflow may wish to attribute commits for the rendered documentation to a specific user. This can now be done via the newly added `committer-name` and `committer-email` action inputs.

The inputs are optional, using the GitHub Actions bot account as the default author.