### PR TITLE
Use new version of libclang

### DIFF
--- a/.github/workflows/render-docs.yml
+++ b/.github/workflows/render-docs.yml
@@ -45,7 +45,7 @@ on:
 
 jobs:
   render-docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
@@ -64,13 +64,13 @@ jobs:
         wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg
 
         # Add the LLVM repository with the GPG keyring
-        echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/focal/ llvm-toolchain-focal-9 main" | sudo tee /etc/apt/sources.list.d/llvm.list > /dev/null
+        echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" | sudo tee /etc/apt/sources.list.d/llvm.list > /dev/null
         
         # Update the package lists
         sudo apt-get -qq update
 
         # Install libclang and other necessary packages
-        sudo apt-get -qq install -y libclang1-9 libclang-cpp9 > /dev/null
+        sudo apt-get install -y libclang1-15 libclang-cpp15
 
     - name: Set up Node.js
       uses: actions/setup-node@v4
@@ -79,7 +79,7 @@ jobs:
         
     - name: Install render-docs
       shell: bash
-      run: npm install github:arduino/render-docs --no-save --silent
+      run: npm install github:arduino/render-docs --no-save
 
     - name: Cache Doxygen binaries
       id: cache-doxygen-binaries

--- a/action.yml
+++ b/action.yml
@@ -42,13 +42,13 @@ runs:
       wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg
 
       # Add the LLVM repository with the GPG keyring
-      echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/focal/ llvm-toolchain-focal-9 main" | sudo tee /etc/apt/sources.list.d/llvm.list > /dev/null
+      echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" | sudo tee /etc/apt/sources.list.d/llvm.list > /dev/null
       
       # Update the package lists
       sudo apt-get -qq update
 
       # Install libclang and other necessary packages
-      sudo apt-get -qq install -y libclang1-9 libclang-cpp9 > /dev/null
+      sudo apt-get install -y libclang1-15 libclang-cpp15
 
   - name: Set up Node.js
     uses: actions/setup-node@v4
@@ -57,7 +57,7 @@ runs:
       
   - name: Install render-docs
     shell: bash
-    run: npm install github:arduino/render-docs --no-save --silent
+    run: npm install github:arduino/render-docs --no-save
 
   - name: Cache Doxygen binaries
     id: cache-doxygen-binaries


### PR DESCRIPTION
This fixes #2 The reason for the issue was that for ubuntu starting v22 `libffi7` is no longer available. The workflow was updated to use a newer version of libclang and consequently a newer version of libffi.
The consequence was that the underlying tool `render-docs` had to be updated as well to use a newer version of doxygen. Otherwise doxygen would fail with `libclang-9.so.1: cannot open shared object file: No such file or directory` because the previous version relied on libclang9.